### PR TITLE
A few contributions

### DIFF
--- a/src/main/scala/com/request/network/lib/artifacts/RequestBurnManagerSimple.scala
+++ b/src/main/scala/com/request/network/lib/artifacts/RequestBurnManagerSimple.scala
@@ -13,8 +13,8 @@ object RequestBurnManagerSimple {
   def apply(): RequestBurnManagerSimple = {
     val fileContent = FileUtil.readFileToString("RequestBurnManagerSimple.json")
     Json.parse(fileContent).validate[RequestBurnManagerSimple] match {
-      case success: JsSuccess[RequestBurnManagerSimple] =>
-        success.get
+      case JsSuccess(requestBurnManagerSimple, _) =>
+        requestBurnManagerSimple
       case error: JsError =>
         throw RequestUnmarshalException(s"Error at unmarshalling RequestBurnManagerSimple json, reason: $error")
     }

--- a/src/main/scala/com/request/network/lib/artifacts/RequestCoreArtifact.scala
+++ b/src/main/scala/com/request/network/lib/artifacts/RequestCoreArtifact.scala
@@ -13,8 +13,8 @@ object RequestCoreArtifact {
   def apply(): RequestCoreArtifact = {
     val fileContent = FileUtil.readFileToString("RequestCore.json")
     Json.parse(fileContent).validate[RequestCoreArtifact] match {
-      case success: JsSuccess[RequestCoreArtifact] =>
-        success.get
+      case JsSuccess(requestCoreArtifact, _) =>
+        requestCoreArtifact
       case error: JsError =>
         throw RequestUnmarshalException(s"Error at unmarshalling RequestCore json, reason: $error")
     }

--- a/src/main/scala/com/request/network/lib/artifacts/RequestEthereumArtifact.scala
+++ b/src/main/scala/com/request/network/lib/artifacts/RequestEthereumArtifact.scala
@@ -5,7 +5,6 @@ import com.request.network.lib.exception.RequestUnmarshalException
 import com.request.network.lib.util.FileUtil
 import play.api.libs.json.{JsError, JsSuccess, Json}
 
-
 @jsonstrict
 case class RequestEthereumArtifact(networks: Map[String, NetworkArtifact])
 
@@ -14,8 +13,8 @@ object RequestEthereumArtifact {
   def apply(): RequestEthereumArtifact = {
     val fileContent = FileUtil.readFileToString("RequestEthereum.json")
     Json.parse(fileContent).validate[RequestEthereumArtifact] match {
-      case success: JsSuccess[RequestEthereumArtifact] =>
-        success.get
+      case JsSuccess(requestEthereumArtifact, _) =>
+        requestEthereumArtifact
       case error: JsError =>
         throw RequestUnmarshalException(s"Error at unmarshalling RequestCore json, reason: $error")
     }

--- a/src/main/scala/com/request/network/lib/artifacts/RequestSynchroneExtensionEscrowArtifact.scala
+++ b/src/main/scala/com/request/network/lib/artifacts/RequestSynchroneExtensionEscrowArtifact.scala
@@ -13,8 +13,8 @@ object RequestSynchroneExtensionEscrowArtifact {
   def apply(): RequestSynchroneExtensionEscrowArtifact = {
     val fileContent = FileUtil.readFileToString("RequestSynchroneExtensionEscrow.json")
     Json.parse(fileContent).validate[RequestSynchroneExtensionEscrowArtifact] match {
-      case success: JsSuccess[RequestSynchroneExtensionEscrowArtifact] =>
-        success.get
+      case JsSuccess(requestSynchroneExtensionEscrowArtifact, _) =>
+        requestSynchroneExtensionEscrowArtifact
       case error: JsError =>
         throw RequestUnmarshalException(s"Error at unmarshalling RequestSynchroneExtensionEscrow json, reason: $error")
     }

--- a/src/main/scala/com/request/network/lib/services/RequestCoreService.scala
+++ b/src/main/scala/com/request/network/lib/services/RequestCoreService.scala
@@ -1,6 +1,5 @@
 package com.request.network.lib.services
 
-import java.math.BigInteger
 import com.request.network.lib.artifacts.RequestCoreArtifact
 import com.request.network.lib.config.RequestConfig
 import com.request.network.lib.contracts.RequestCore
@@ -8,39 +7,96 @@ import com.request.network.lib.wrappers.{IpfsWrapper, Web3Wrapper}
 import org.web3j.crypto.WalletUtils
 import org.web3j.tx.{Contract, ManagedTransaction}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class RequestCoreService()(implicit
                            ipfs: IpfsWrapper,
                            web3Wrapper: Web3Wrapper,
                            requestCoreArtifact: RequestCoreArtifact,
                            requestConfig: RequestConfig) {
-  require(!requestCoreArtifact.networks.contains(web3Wrapper.networkName), s"RequestCore Artifact does not have configuration for network: ${web3Wrapper.networkName}")
+  require(
+    !requestCoreArtifact.networks.contains(web3Wrapper.networkName),
+    s"RequestCore Artifact does not have configuration for network: ${web3Wrapper.networkName}"
+  )
 
-  val addressRequestCore: String = requestCoreArtifact.networks(web3Wrapper.networkName).address
+  val addressRequestCore: String =
+    requestCoreArtifact.networks(web3Wrapper.networkName).address
+
   //TODO not sure if we need this
-  private val credentials = WalletUtils.loadCredentials("password", "/path/to/walletfile")
-  private val requestCore: RequestCore = RequestCore.deploy(web3Wrapper.web3j, credentials, ManagedTransaction.GAS_PRICE, Contract.GAS_LIMIT).send()
+  private val credentials =
+    WalletUtils.loadCredentials("password", "/path/to/walletfile")
+
+  private val requestCore: RequestCore = RequestCore
+    .deploy(web3Wrapper.web3j, credentials, ManagedTransaction.GAS_PRICE, Contract.GAS_LIMIT)
+    .send()
 
   /**
     * get the number of the last request (N.B: number !== id)
     * @return  future of the number of the last request
     */
-  def getCurrentNumRequest: Future[BigInteger] = requestCore.numRequests().sendAsync()
+  def getCurrentNumRequest(implicit executionContext: ExecutionContext): Future[BigInt] =
+    requestCore.numRequests().sendAsync().asScala.map(BigInt(_))
 
   /**
     * get the version of the contract
     * @return  future of the version of the contract
     */
-  def getVersion: Future[BigInteger] = requestCore.VERSION().sendAsync()
+  def getVersion(implicit executionContext: ExecutionContext): Future[BigInt] =
+    requestCore.VERSION().sendAsync().asScala.map(BigInt(_))
 
-  def getCollectEstimation(expectedAmount: Double, currencyContract: String, extension: String) = ???
+  /**
+    * get the estimation of ether (in wei) needed to create a request
+    * @param   expectedAmount    amount expected of the request
+    * @param   currencyContract  address of the currency contract of the request
+    * @param   extension         address of the extension contract of the request
+    * @return  future of the number of wei needed to create the request
+    */
+  def getCollectEstimation(expectedAmount: BigInt, currencyContract: String, extension: String)(
+      implicit executionContext: ExecutionContext): Future[BigInt] = {
+    if (!web3Wrapper.isAddressNoChecksum(currencyContract)) {
+      Future.failed(new RuntimeException("currencyContract must be a valid eth address"))
+    } else if (extension.nonEmpty && !web3Wrapper.isAddressNoChecksum(extension)) {
+      Future.failed(new RuntimeException("extension must be a valid eth address"))
+    } else {
+      requestCore
+        .getCollectEstimation(expectedAmount.bigInteger, currencyContract, extension)
+        .sendAsync().asScala
+        .map(BigInt(_))
+    }
+  }
 
-  def getRequest(requestID: String) = ???
+  /**
+    * get a request by its requestId
+    * @param   requestId    requestId of the request
+    * @return  future of the object containing the request
+    */
+  def getRequest(requestId: String): Future[Any] = {
+    if(!web3Wrapper.isHexStrictBytes32(requestId)) {
+      Future.failed(new RuntimeException("requestId must be a 32 bytes hex string"))
+    } else {
+      ???
+    }
+  }
 
-  def getRequestByTransactionHash(hash: String) = ???
+  /**
+    * get a request and method called by the hash of a transaction
+    * @param   hash    hash of the ethereum transaction
+    * @return  future of the object containing the request and the transaction
+    */
+  def getRequestByTransactionHash(hash: String)(
+    implicit executionContext: ExecutionContext): Future[Any] = {
+    web3Wrapper.getTransaction(hash).asScala.map { ethTransaction =>
+      ethTransaction.getTransaction.asScala.map { transaction =>
+        val ccyContract = transaction.getTo
 
-  def getRequestEvents(requestID: String, fromBlock: Option[Int], toBlock: Option[Int]) = ???
+        val ccyContractservice = ???
+
+        ???
+      }.getOrElse(new RuntimeException("transaction not found"))
+    }
+  }
+
+  def getRequestEvents(requestId: String, fromBlock: Option[Int], toBlock: Option[Int]) = ???
 
   def getRequestsByAddress(address: String, fromBlock: Option[Int], toBlock: Option[Int]) = ???
 

--- a/src/main/scala/com/request/network/lib/services/RequestEthereumService.scala
+++ b/src/main/scala/com/request/network/lib/services/RequestEthereumService.scala
@@ -2,7 +2,7 @@ package com.request.network.lib.services
 
 import com.request.network.lib.artifacts.{RequestCoreArtifact, RequestEthereumArtifact}
 import com.request.network.lib.config.RequestConfig
-import com.request.network.lib.contracts.{RequestCore, RequestEthereum}
+import com.request.network.lib.contracts.RequestEthereum
 import com.request.network.lib.data.{RequestAdditional, RequestExtension, RequestOption}
 import com.request.network.lib.wrappers.{IpfsWrapper, Web3Wrapper}
 import org.web3j.crypto.WalletUtils

--- a/src/main/scala/com/request/network/lib/services/package.scala
+++ b/src/main/scala/com/request/network/lib/services/package.scala
@@ -1,14 +1,19 @@
 package com.request.network.lib
 
+import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
 import scala.compat.java8.FutureConverters
-import scala.concurrent.Future
+import scala.compat.java8.OptionConverters
 
 package object services {
 
-  implicit def implicitFuture[A](completableFuture: CompletableFuture[A]): Future[A] = {
-    FutureConverters.toScala(completableFuture)
+  implicit class implicitFuture[A](completableFuture: CompletableFuture[A]) {
+    def asScala = FutureConverters.toScala(completableFuture)
+  }
+
+  implicit class implicitOption[A](optional: Optional[A]) {
+    def asScala = OptionConverters.toScala(optional)
   }
 
 }

--- a/src/main/scala/com/request/network/lib/wrappers/Web3Wrapper.scala
+++ b/src/main/scala/com/request/network/lib/wrappers/Web3Wrapper.scala
@@ -1,6 +1,9 @@
 package com.request.network.lib.wrappers
 
+import java.util.concurrent.CompletableFuture
+
 import com.request.network.lib.config.RequestConfig
+import org.web3j.protocol.core.methods.response.{EthGetTransactionReceipt, EthTransaction}
 import org.web3j.protocol.{Web3j, Web3jService}
 import org.web3j.protocol.http.HttpService
 
@@ -14,8 +17,6 @@ class Web3Wrapper(web3jService: Option[Web3jService], networkId: Option[Int])
     new HttpService(requestConfig.ethereumNodeUrlDefault(requestConfig.ethereumDefault)))
   )
   val networkName: String = networkId.map(getNetworkName).getOrElse(requestConfig.ethereumDefault)
-
-  def BN() = ???
 
   def getNetworkName(networkId: Int): String = {
     networkId match {
@@ -50,9 +51,9 @@ class Web3Wrapper(web3jService: Option[Web3jService], networkId: Option[Int])
 
   def setUpOptions(options: Any): Any = ???
 
-  def getTransactionReceipt(hash: String): Future[Any] = ???
+  def getTransactionReceipt(hash: String): CompletableFuture[EthGetTransactionReceipt] = web3j.ethGetTransactionReceipt(hash).sendAsync()
 
-  def getTransaction(hash: String): Future[Any] = ???
+  def getTransaction(hash: String): CompletableFuture[EthTransaction] = web3j.ethGetTransactionByHash(hash).sendAsync()
 
   def getBlockTimestamp(blockNumber: Int): Future[Any] = ???
 


### PR DESCRIPTION
Changed the JSON parsing to use pattern matching for safe access for validated JSON.
Changed the implicit future conversion to use the converter pattern, this is generally accepted as less surprising than direct implicit conversions. (See e.g. JavaConverters)
Mapped results from java's BigInteger to scala.math.BigInt, unfortunately this will require an implicit executioncontext.
Removed the BN method from Web3Wrapper, since it is merely a thing used in JavaScript as a util to handle conversion to "BigNumber" (BN), and we don't need that in Scala.